### PR TITLE
Enable the reverse to reach the backend on AWS

### DIFF
--- a/rootfs/usr/local/bin/functions
+++ b/rootfs/usr/local/bin/functions
@@ -58,7 +58,7 @@ f_gen_location() {
             mkdir -p /nginx/auth/${domain_name}
             export frontend_auth=${FRONTEND_AUTH}
             export frontend_path=${FRONTEND_PATH}
-            export backend_addr=${container_name}
+            export backend_addr=${BACKEND_HOSTNAME}
             export frontend_path=${FRONTEND_PATH}
             export backend_port=${BACKEND_PORT}
             export auth_file=${auth_file}
@@ -221,6 +221,9 @@ f_make_conf() {
             esac
         done
         IFS=${OLD_IFS}
+        THIS_CONTAINER_ID=$(hostname)
+        THIS_CONTAINER_NAME=$(curl --unix-socket /var/run/docker.sock http://localhost/containers/${THIS_CONTAINER_ID}/json 2> /dev/null | jq '.Name' | sed -e 's|.*"/\(.*\)"$|\1|')
+        BACKEND_HOSTNAME=$(curl --unix-socket /var/run/docker.sock http://localhost/containers/${THIS_CONTAINER_ID}/json 2> /dev/null | jq '.HostConfig.Links' | grep -E "/${THIS_CONTAINER_NAME}/" | sed 's|.*/\(.*\)"|\1|')
         f_log INF "Generate configuration for ${FRONTEND_DOMAIN}, with options :"
         f_log INF "             path=${FRONTEND_PATH}"
         f_log INF "             auth=${FRONTEND_AUTH}" 

--- a/rootfs/usr/local/bin/functions
+++ b/rootfs/usr/local/bin/functions
@@ -223,7 +223,7 @@ f_make_conf() {
         IFS=${OLD_IFS}
         THIS_CONTAINER_ID=$(hostname)
         THIS_CONTAINER_NAME=$(curl --unix-socket /var/run/docker.sock http://localhost/containers/${THIS_CONTAINER_ID}/json 2> /dev/null | jq '.Name' | sed -e 's|.*"/\(.*\)"$|\1|')
-        BACKEND_HOSTNAME=$(curl --unix-socket /var/run/docker.sock http://localhost/containers/${THIS_CONTAINER_ID}/json 2> /dev/null | jq '.HostConfig.Links' | grep -E "/${THIS_CONTAINER_NAME}/" | sed 's|.*/\(.*\)"|\1|')
+        BACKEND_HOSTNAME=$(curl --unix-socket /var/run/docker.sock http://localhost/containers/${THIS_CONTAINER_ID}/json 2> /dev/null | jq '.HostConfig.Links' | grep -E "/${THIS_CONTAINER_NAME}/" | grep ${container_name} | sed 's|.*/\(.*\)",*|\1|')
         f_log INF "Generate configuration for ${FRONTEND_DOMAIN}, with options :"
         f_log INF "             path=${FRONTEND_PATH}"
         f_log INF "             auth=${FRONTEND_AUTH}" 


### PR DESCRIPTION
Before this change, the generated config used the backend container's name as the hostname to forward requests to. On AWS, this didn't work: you need to create a link and since you can't anticipate the name of the running container, the alias of the link is pretty much guaranteed not to be the backend's hostname. This change reads the reverse config to find the alias given by the user to the backend container, which is indeed resolvable and makes it all work.
Disclaimer: I didn't get the chance to check if the change breaks things outside of AWS, since I don't have access to an infrastructure that would allow me to do so. My guess is it won't as long as a link is setup from the reverse to the backend.